### PR TITLE
Make extban matching work for all IRCDs

### DIFF
--- a/include/protocol.h
+++ b/include/protocol.h
@@ -73,6 +73,8 @@ class CoreExport IRCDProto : public Service
 	unsigned MaxModes;
 	/* The maximum number of bytes a line may have */
 	unsigned MaxLine;
+	/* Extban list */
+	std::vector<Anope::string> extbanNames;
 
 	/* Retrieves the next free UID or SID */
 	virtual Anope::string UID_Retrieve();
@@ -237,6 +239,9 @@ class CoreExport IRCDProto : public Service
 	virtual bool IsIdentValid(const Anope::string &);
 	virtual bool IsHostValid(const Anope::string &);
 	virtual bool IsExtbanValid(const Anope::string &) { return false; }
+	virtual bool IsExtban(const Anope::string &, const Anope::string &);
+
+	virtual void AddExtban(const Anope::string &);
 
 	/** Retrieve the maximum number of list modes settable on this channel
 	 * Defaults to Config->ListSize

--- a/modules/protocol/inspircd12.cpp
+++ b/modules/protocol/inspircd12.cpp
@@ -480,10 +480,13 @@ class InspIRCd12Proto : public IRCDProto
 class InspIRCdExtBan : public ChannelModeList
 {
  public:
-	InspIRCdExtBan(const Anope::string &mname, char modeChar) : ChannelModeList(mname, modeChar) { }
+	InspIRCdExtBan(const Anope::string &mname, char modeChar) : ChannelModeList(mname, modeChar)
+	{
+		IRCD->AddExtban(mname);
+	}
 
 	bool Matches(User *u, const Entry *e) anope_override
-	{
+	{ /* FIXME these matches will never work, as e->GetMask will return only "unwrapped" mask! */
 		const Anope::string &mask = e->GetMask();
 
 		if (mask.find("m:") == 0 || mask.find("N:") == 0)

--- a/modules/protocol/inspircd20.cpp
+++ b/modules/protocol/inspircd20.cpp
@@ -109,6 +109,7 @@ class InspIRCdExtBan : public ChannelModeVirtual<ChannelModeList>
 	InspIRCdExtBan(const Anope::string &mname, const Anope::string &basename, char extban) : ChannelModeVirtual<ChannelModeList>(mname, basename)
 		, ext(extban)
 	{
+		IRCD->AddExtban(mname);
 	}
 
 	ChannelMode *Wrap(Anope::string &param) anope_override
@@ -139,9 +140,8 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Entry(this->name, real_mask).Matches(u);
+			return Entry(this->name, mask).Matches(u);
 		}
 	};
 
@@ -154,9 +154,7 @@ namespace InspIRCdExtban
 
 		bool Matches(User *u, const Entry *e) anope_override
 		{
-			const Anope::string &mask = e->GetMask();
-
-			Anope::string channel = mask.substr(3);
+			Anope::string channel = e->GetMask();
 
 			ChannelMode *cm = NULL;
 			if (channel[0] != '#')
@@ -191,9 +189,8 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
 
-			return u->IsIdentified() && real_mask.equals_ci(u->Account()->display);
+			return u->IsIdentified() && mask.equals_ci(u->Account()->display);
 		}
 	};
 
@@ -207,8 +204,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return Anope::Match(u->realname, real_mask);
+			return Anope::Match(u->realname, mask);
 		}
 	};
 
@@ -222,8 +218,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return Anope::Match(u->server->GetName(), real_mask);
+			return Anope::Match(u->server->GetName(), mask);
 		}
 	};
 
@@ -237,8 +232,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, real_mask);
+			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, mask);
 		}
 	};
 
@@ -252,8 +246,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return !u->Account() && Entry("BAN", real_mask).Matches(u);
+			return !u->Account() && Entry("BAN", mask).Matches(u);
 		}
 	};
 }

--- a/modules/protocol/inspircd3.cpp
+++ b/modules/protocol/inspircd3.cpp
@@ -534,6 +534,7 @@ class InspIRCdExtBan : public ChannelModeVirtual<ChannelModeList>
 	InspIRCdExtBan(const Anope::string &mname, const Anope::string &basename, char extban) : ChannelModeVirtual<ChannelModeList>(mname, basename)
 		, ext(extban)
 	{
+		IRCD->AddExtban(mname);
 	}
 
 	ChannelMode *Wrap(Anope::string &param) anope_override
@@ -564,9 +565,8 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Entry(this->name, real_mask).Matches(u);
+			return Entry(this->name, mask).Matches(u);
 		}
 	};
 
@@ -579,9 +579,7 @@ namespace InspIRCdExtban
 
 		bool Matches(User *u, const Entry *e) anope_override
 		{
-			const Anope::string &mask = e->GetMask();
-
-			Anope::string channel = mask.substr(3);
+			Anope::string channel = e->GetMask();
 
 			ChannelMode *cm = NULL;
 			if (channel[0] != '#')
@@ -616,9 +614,8 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
 
-			return u->IsIdentified() && real_mask.equals_ci(u->Account()->display);
+			return u->IsIdentified() && mask.equals_ci(u->Account()->display);
 		}
 	};
 
@@ -632,8 +629,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return Anope::Match(u->realname, real_mask);
+			return Anope::Match(u->realname, mask);
 		}
 	};
 
@@ -647,8 +643,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return Anope::Match(u->server->GetName(), real_mask);
+			return Anope::Match(u->server->GetName(), mask);
 		}
 	};
 
@@ -662,8 +657,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, real_mask);
+			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, mask);
 		}
 	};
 
@@ -677,8 +671,7 @@ namespace InspIRCdExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(2);
-			return !u->Account() && Entry("BAN", real_mask).Matches(u);
+			return !u->Account() && Entry("BAN", mask).Matches(u);
 		}
 	};
 }

--- a/modules/protocol/unreal.cpp
+++ b/modules/protocol/unreal.cpp
@@ -424,6 +424,7 @@ class UnrealExtBan : public ChannelModeVirtual<ChannelModeList>
 	UnrealExtBan(const Anope::string &mname, const Anope::string &basename, char extban) : ChannelModeVirtual<ChannelModeList>(mname, basename)
 		, ext(extban)
 	{
+		IRCD->AddExtban(mname);
 	}
 
 	ChannelMode *Wrap(Anope::string &param) anope_override
@@ -453,8 +454,7 @@ namespace UnrealExtban
 
 		bool Matches(User *u, const Entry *e) anope_override
 		{
-			const Anope::string &mask = e->GetMask();
-			Anope::string channel = mask.substr(3);
+			Anope::string channel = e->GetMask();
 
 			ChannelMode *cm = NULL;
 			if (channel[0] != '#')
@@ -489,9 +489,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Entry(this->name, real_mask).Matches(u);
+			return Entry(this->name, mask).Matches(u);
 		}
 	};
 
@@ -505,9 +504,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Anope::Match(u->realname, real_mask);
+			return Anope::Match(u->realname, mask);
 		}
 	};
 
@@ -535,9 +533,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return u->Account() && Anope::Match(u->Account()->display, real_mask);
+			return u->Account() && Anope::Match(u->Account()->display, mask);
 		}
 	};
 }

--- a/modules/protocol/unreal4.cpp
+++ b/modules/protocol/unreal4.cpp
@@ -443,6 +443,7 @@ class UnrealExtBan : public ChannelModeVirtual<ChannelModeList>
 	UnrealExtBan(const Anope::string &mname, const Anope::string &basename, char extban) : ChannelModeVirtual<ChannelModeList>(mname, basename)
 		, ext(extban)
 	{
+		IRCD->AddExtban(mname);
 	}
 
 	ChannelMode *Wrap(Anope::string &param) anope_override
@@ -472,8 +473,7 @@ namespace UnrealExtban
 
 		bool Matches(User *u, const Entry *e) anope_override
 		{
-			const Anope::string &mask = e->GetMask();
-			Anope::string channel = mask.substr(3);
+			Anope::string channel = e->GetMask();
 
 			ChannelMode *cm = NULL;
 			if (channel[0] != '#')
@@ -508,9 +508,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Entry(this->name, real_mask).Matches(u);
+			return Entry(this->name, mask).Matches(u);
 		}
 	};
 
@@ -524,9 +523,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			return Anope::Match(u->realname, real_mask);
+			return Anope::Match(u->realname, mask);
 		}
 	};
 
@@ -554,12 +552,11 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 
-			if (real_mask == "0" && !u->Account()) /* ~a:0 is special and matches all unauthenticated users */
+			if (mask == "0" && !u->Account()) /* ~a:0 is special and matches all unauthenticated users */
 				return true;
 
-			return u->Account() && Anope::Match(u->Account()->display, real_mask);
+			return u->Account() && Anope::Match(u->Account()->display, mask);
 		}
 	};
 
@@ -573,8 +570,7 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
-			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, real_mask);
+			return !u->fingerprint.empty() && Anope::Match(u->fingerprint, mask);
 		}
 	};
 	
@@ -588,9 +584,8 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 			ModData *moddata = u->GetExt<ModData>("ClientModData");
-			return moddata != NULL && moddata->find("operclass") != moddata->end() && Anope::Match((*moddata)["operclass"], real_mask);
+			return moddata != NULL && moddata->find("operclass") != moddata->end() && Anope::Match((*moddata)["operclass"], mask);
 		}
 	};
 	
@@ -605,8 +600,7 @@ namespace UnrealExtban
 		{
 			/* strip down the time (~t:1234:) and call other matchers */
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
-			real_mask = real_mask.substr(real_mask.find(":") + 1);
+			Anope::string real_mask = mask.substr(real_mask.find(":") + 1);
 			return Entry("BAN", real_mask).Matches(u);
 		}
 	};
@@ -621,7 +615,6 @@ namespace UnrealExtban
 		bool Matches(User *u, const Entry *e) anope_override
 		{
 			const Anope::string &mask = e->GetMask();
-			Anope::string real_mask = mask.substr(3);
 			ModData *moddata = u->GetExt<ModData>("ClientModData");
 			if (moddata == NULL || moddata->find("geoip") == moddata->end())
 				return false;
@@ -631,7 +624,7 @@ namespace UnrealExtban
 			while (sep.GetToken(tokenbuf))
 			{
 				if (tokenbuf.rfind("cc=", 0) == 0)
-					return (tokenbuf.substr(3, 2) == real_mask);
+					return (tokenbuf.substr(3, 2) == mask);
 			}
 			return false;
 		}

--- a/src/modes.cpp
+++ b/src/modes.cpp
@@ -849,14 +849,13 @@ const Anope::string Entry::GetNUHMask() const
 bool Entry::Matches(User *u, bool full) const
 {
 	/* First check if this mode has defined any matches (usually for extbans). */
-	if (IRCD->IsExtbanValid(this->mask))
+	if (IRCD->IsExtban(this->name, this->mask))
 	{
 		ChannelMode *cm = ModeManager::FindChannelModeByName(this->name);
 		if (cm != NULL && cm->type == MODE_LIST)
 		{
 			ChannelModeList *cml = anope_dynamic_static_cast<ChannelModeList *>(cm);
-			if (cml->Matches(u, this))
-				return true;
+			return (cml->Matches(u, this));
 		}
 	}
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -450,6 +450,16 @@ Anope::string IRCDProto::NormalizeMask(const Anope::string &mask)
 	return Entry("", mask).GetNUHMask();
 }
 
+bool IRCDProto::IsExtban(const Anope::string &mname, const Anope::string &mmask)
+{
+	return std::find(extbanNames.begin(), extbanNames.end(), mname) != extbanNames.end();
+}
+
+void IRCDProto::AddExtban(const Anope::string &mname)
+{
+	extbanNames.push_back(mname);
+}
+
 MessageSource::MessageSource(const Anope::string &src) : source(src), u(NULL), s(NULL)
 {
 	/* no source for incoming message is our uplink */


### PR DESCRIPTION
(except inspircd12 for now).
This will keep internal data format (and thus databases) unchanged. Note that only unreal4 has been tested.

<!--
Please fill in the template below. It will help us process your pull request a lot faster.
-->

## Summary

<!--
Briefly describe what this pull request changes.
-->

## Rationale

<!--
Describe why you have made this change.
-->

## Testing Environment

<!--
Describe the environment in which you have tested this change:
-->

I have tested this pull request on:

**Operating system name and version:** <!-- e.g. Linux 3.11 -->
**Compiler name and version:** <!-- e.g. GCC 4.2.0 -->
